### PR TITLE
Runtime layer builds into a single .psm1 file

### DIFF
--- a/powershell-runtime/Makefile
+++ b/powershell-runtime/Makefile
@@ -1,6 +1,5 @@
 PWSH_VERSION ?= 7.2.4
 PWSH_ARCHITECTURE ?= x64
-#x64 or #arm64 
 build-PwshRuntimeLayer:
 # Download and extract PowerShell binaries. Remove downloaded file
 	curl -L -o $(ARTIFACTS_DIR)/powershell-$(PWSH_VERSION)-$(PWSH_ARCHITECTURE).tar.gz https://github.com/PowerShell/PowerShell/releases/download/v$(PWSH_VERSION)/powershell-$(PWSH_VERSION)-linux-$(PWSH_ARCHITECTURE).tar.gz
@@ -12,6 +11,11 @@ build-PwshRuntimeLayer:
 
 # Copy additional runtime files, including bootstrap. Remove Makefile from destination
 	cp -R ./pwsh-runtime/* $(ARTIFACTS_DIR)
+
+# Merge all Private module content into a single .psm1 file to speed up module loading
+	cd $(ARTIFACTS_DIR)/modules/Private
+	tail -n +3 -q $(ARTIFACTS_DIR)/modules/Private/*.ps1 >> $(ARTIFACTS_DIR)/modules/pwsh-runtime.psm1
+	rm -Rf $(ARTIFACTS_DIR)/modules/Private
 
 # Make bootstrap script executable
 	chmod +x $(ARTIFACTS_DIR)/bootstrap

--- a/powershell-runtime/pwsh-runtime/modules/pwsh-runtime.psm1
+++ b/powershell-runtime/pwsh-runtime/modules/pwsh-runtime.psm1
@@ -2,12 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Set-PSDebug -Strict
-
-# Instantiated to be available within the scope of the files dot-sourced below.
-$Script:ModuleRoot = $PSScriptRoot
-
-$privateFunctionsPath = Join-Path -Path "$PSScriptRoot" -ChildPath 'Private'
-$publicFunctionsPath = Join-Path -Path "$PSScriptRoot" -ChildPath 'Public'
-
-# Dot-source each private and public function during import of module.
-Get-ChildItem -Path $privateFunctionsPath, $publicFunctionsPath -Filter *.ps1 -Recurse | ForEach-Object {. $_.FullName}


### PR DESCRIPTION
*Description of changes:*

Updated the `pwsh-runtime` layer build process, such that all `.ps1` script files are built into the `pwsh-runtime.psm1` module file. This speeds up the time taken to load the module as there is no evaluation of the file system or dot-sourcing of script files. This change reduces AWS Lambda init times.

When tested with a small sample size of cold start executions (ten execution before and after), with a Lambda Function configured with `1024MB` of memory, this change improves Init Duration by ~200ms on average.

## Testing

The data shows the Init Duration decreases when using a combined `pwsh-runtime.psm1` file. The data shows a faster minimum, a faster maximum and a lower average Init Duration.

```text
PS> $output = foreach ($group in ($data | Group-Object -Property Psm1Format)) {
  $measured = $group.Group.InitDuration | Measure-Object -Average -Maximum -Minimum
  [PSCustomObject]@{
    Name = $group.Name
    Maximum = $measured.Maximum
    Minimum = $measured.Minimum
    Average = $measured.Average
  }
}
$output | Format-Table

Name      Maximum  Minimum  Average
----      -------  -------  -------
Combined 1312.510  998.160 1139.207
Separate 1496.960 1176.150 1334.301
```

The raw init duration data in CSV format:

```text
PS> $data | ConvertTo-Csv -NoTypeInformation

"Timestamp","Psm1Format","InitDuration"
"6:58:22 PM","Separate","1300.3"
"6:58:16 PM","Separate","1176.15"
"6:58:10 PM","Separate","1372.58"
"6:58:04 PM","Separate","1388.13"
"6:57:58 PM","Separate","1293.61"
"6:57:51 PM","Separate","1330.09"
"6:57:45 PM","Separate","1301.94"
"6:57:38 PM","Separate","1382.89"
"6:57:31 PM","Separate","1300.36"
"6:57:24 PM","Separate","1496.96"
"6:52:41 PM","Combined","1312.51"
"6:52:34 PM","Combined","1054.31"
"6:52:28 PM","Combined","1014.99"
"6:52:21 PM","Combined","1147.13"
"6:52:15 PM","Combined","1044.26"
"6:52:09 PM","Combined","1142.47"
"6:52:02 PM","Combined","998.16"
"6:51:56 PM","Combined","1194.04"
"6:51:49 PM","Combined","1235.42"
"6:51:41 PM","Combined","1248.78"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
