### PR TITLE
Reverted the function to x86_64

### DIFF
--- a/examples/demo-runtime-layer-function/template.yml
+++ b/examples/demo-runtime-layer-function/template.yml
@@ -17,7 +17,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Architectures:
-        - arm64
+        - x86_64
       Description: PowerShell-Lambda-Runtime Demo Function
       CodeUri: function/
       Runtime: provided.al2


### PR DESCRIPTION
*Issue #:* [18](https://github.com/awslabs/aws-lambda-powershell-runtime/issues/18)

*Description of changes:*

Reverted the `demo-runtime-layer-function` example to use `x86_64` for the CPU architecture.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
