### PR TITLE
Updated to PowerShell 7.4.0 by default

### DIFF
--- a/powershell-runtime/build-PwshRuntimeLayer.ps1
+++ b/powershell-runtime/build-PwshRuntimeLayer.ps1
@@ -4,7 +4,7 @@
 #>
 param (
     # The version of PowerShell to use for the runtime
-    [string]$PwshVersion = '7.2.13',
+    [string]$PwshVersion = '7.4.0',
 
     # The desired CPU architecture for the runtime
     [ValidateSet('arm64', 'x64')]

--- a/powershell-runtime/source/Makefile
+++ b/powershell-runtime/source/Makefile
@@ -1,5 +1,5 @@
 # PWSH_VERSION is version of PowerShell to download
-PWSH_VERSION ?= 7.2.13
+PWSH_VERSION ?= 7.4.0
 # PWSH_ARCHITECTURE can be 'x64' or 'arm64'
 PWSH_ARCHITECTURE ?= x64
 build-PwshRuntimeLayer:


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Updated the default version of PowerShell used by the runtime to the latest LTS release, `v7.4.0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
