### PR TITLE
Added support for the provided.al2023 runtime.

### DIFF
--- a/examples/demo-runtime-layer-function/template.yml
+++ b/examples/demo-runtime-layer-function/template.yml
@@ -20,13 +20,16 @@ Resources:
         - x86_64
       Description: PowerShell-Lambda-Runtime Demo Function
       CodeUri: function/
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Handler: examplehandler.ps1::handler
       MemorySize: 1024
       Timeout: 100
       Layers:
         - !Ref PwshRuntimeLayer
         - !Ref DemoAWSToolsLayer
+      Environment:
+        Variables:
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1'
     Metadata:
       BuildMethod: makefile
 ##########################################################################
@@ -39,6 +42,7 @@ Resources:
       ContentUri: ../../powershell-runtime/source
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile
@@ -57,6 +61,7 @@ Resources:
       ContentUri: ../../powershell-modules/AWSToolsforPowerShell/Demo-AWS.Tools/buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/examples/demo-s3-lambda-eventbridge/template.yml
+++ b/examples/demo-s3-lambda-eventbridge/template.yml
@@ -39,7 +39,7 @@ Resources:
     Properties:
       Description: PowerShell-Lambda-Runtime Demo Function
       CodeUri: function/
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Handler: Module::demo-s3-lambda-eventbridge::handler
       MemorySize: 1024
       Timeout: 100
@@ -54,6 +54,7 @@ Resources:
       Environment:
         Variables:
           DESTINATION_BUS: !Ref PowerShellEventBus
+          DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: '1'
       Events:
         S3NewObjectEvent:
           Type: S3
@@ -75,6 +76,7 @@ Resources:
       ContentUri: ../../powershell-runtime/source
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       LicenseInfo: 'Available under the MIT-0 license.'
       RetentionPolicy: Delete
     Metadata:
@@ -87,6 +89,7 @@ Resources:
       ContentUri: ../../powershell-modules/AWSToolsforPowerShell/AWS.Tools.S3EventBridge/buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       LicenseInfo: 'Available under the MIT-0 license.'
       RetentionPolicy: Delete
     Metadata:

--- a/powershell-modules/AWSToolsforPowerShell/AWS.Tools.All/template.yml
+++ b/powershell-modules/AWSToolsforPowerShell/AWS.Tools.All/template.yml
@@ -20,6 +20,7 @@ Resources:
       ContentUri: buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/powershell-modules/AWSToolsforPowerShell/AWS.Tools.Common/template.yml
+++ b/powershell-modules/AWSToolsforPowerShell/AWS.Tools.Common/template.yml
@@ -20,6 +20,7 @@ Resources:
       ContentUri: buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/powershell-modules/AWSToolsforPowerShell/AWS.Tools.S3EventBridge/template.yml
+++ b/powershell-modules/AWSToolsforPowerShell/AWS.Tools.S3EventBridge/template.yml
@@ -20,6 +20,7 @@ Resources:
       ContentUri: buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/powershell-modules/AWSToolsforPowerShell/Demo-AWS.Tools/template.yml
+++ b/powershell-modules/AWSToolsforPowerShell/Demo-AWS.Tools/template.yml
@@ -20,6 +20,7 @@ Resources:
       ContentUri: ./buildlayer
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/powershell-modules/VMwarePowerCLI/template.yml
+++ b/powershell-modules/VMwarePowerCLI/template.yml
@@ -20,7 +20,8 @@ Resources:
       Description: Layer containing VMware PowerCLI
       ContentUri: PowerCLI
       CompatibleRuntimes:
-        - provided.al2      
+        - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile

--- a/powershell-runtime/readme.md
+++ b/powershell-runtime/readme.md
@@ -169,3 +169,25 @@ The runtime can terminate your function because it ran out of time, detected a s
 Your function code can throw an exception or return an error object. Lambda writes the error to CloudWatch Logs and, for synchronous invocations, also returns the error in the function response output.
 
 See the [documentation](https://docs.aws.amazon.com/lambda/latest/dg/powershell-exceptions.html) on how to view Lambda function invocation errors for the PowerShell runtime using the Lambda console and the AWS CLI.
+
+### Provided Runtime options
+
+The runtime supports both the `provided.al2` and `provided.al2023` Lambda runtimes.
+
+#### provided.al2023
+
+To work as expected in the `provided.al2023` runtime, the environment variable `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` must be set to `1`. This is to prevent the need for installing the `libicu` package. If this is an issue for your environment, either continue using `provided.al2`, or open an issue in this GitHub repository.
+
+If this environment variable is not configured, the following error will likely be shown the your function logs. The error includes a link to a [Microsoft documentation page](https://aka.ms/dotnet-missing-libicu) for more information.
+
+```text
+Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu (or icu-libs) using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
+at System.Environment.FailFast(System.String)
+at System.Globalization.GlobalizationMode+Settings..cctor()
+at System.Globalization.CultureData.CreateCultureWithInvariantData()
+at System.Globalization.CultureData.get_Invariant()
+at System.Globalization.CultureInfo..cctor()
+at System.Globalization.CultureInfo.get_CurrentUICulture()
+at Microsoft.PowerShell.UnmanagedPSEntry.Start(System.String[], Int32)
+at Microsoft.PowerShell.ManagedPSEntry.Main(System.String[])
+```

--- a/powershell-runtime/template.yml
+++ b/powershell-runtime/template.yml
@@ -15,6 +15,7 @@ Resources:
       ContentUri: ./source
       CompatibleRuntimes:
         - provided.al2
+        - provided.al2023
       RetentionPolicy: Delete
     Metadata:
       BuildMethod: makefile


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

AWS Lambda [released support](https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/) for the Amazon Linux 2023 runtime. This change updates the appropriate samples and templates to support this runtime.

In my local testing, `provided.al2023` cold starts ~200ms faster than `provided.al2` when using 2048MB Memory. As such, the demo functions in this repository have been updated to use the newer runtime. This change should not affect any downstream usage of the runtime layer included by default, as the layer is only updated to add the flag, indicating support for `provided.al2023`. To actually change this, consumers will need to change their Lambda Function configurations.

Please note the `Provided Runtime options` section of the [powershell-runtime readme](https://github.com/awslabs/aws-lambda-powershell-runtime/blob/main/powershell-runtime/readme.md), which includes specifics around what's needed to make this change in your Lambda Functions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
