### PR TITLE
Migrate custom runtime calls to System.Net.Http.HttpClient

### DIFF
--- a/powershell-runtime/source/bootstrap
+++ b/powershell-runtime/source/bootstrap
@@ -13,6 +13,11 @@ if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host "[RUNTIME-bootstrap]
 if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]Importing runtime module helpers'}
 Import-Module '/opt/modules/pwsh-runtime.psd1'
 
+# Importing .NET class from .cs file to support the script property "RemainingTime" and method "getRemainingTimeInMillis".
+# This is taken from the Lambda .Net runtime LambdaContext code: https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.Core/ILambdaContext.cs
+if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-bootstrap]Importing .NET class from .cs file to support script properties and method' }
+Add-Type -TypeDefinition ([System.IO.File]::ReadAllText('/opt/PowerShellLambdaContext.cs'))
+
 # Modify $env:PSModulePath to support Lambda paths
 if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]Modify PSModulePath to support Lambda paths'}
 Set-PSModulePath
@@ -35,13 +40,16 @@ switch ($private:handlerArray.handlerType) {
     }
 }
 
+$private:httpClient = [System.Net.Http.HttpClient]::new()
+$private:httpClient.Timeout = [System.Threading.Timeout]::InfiniteTimeSpan
+
 ## Event loop
 # Processes invocation events from Lambda Runtime API in a loop until runtime environment is terminated.
 if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]Start event loop'}
 do {
     # Get /NEXT invocation from AWS Lambda Runtime API.
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]Get /NEXT invocation from AWS Lambda Runtime API'}
-    $private:runtimeNextInvocationResponse = Get-LambdaNextInvocation
+    $private:runtimeNextInvocationResponse = Get-LambdaNextInvocation $private:httpClient
 
     # Set default and AWS Lambda specific environment variables for each invocation
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]Set default and AWS Lambda specific environment variables for each invocation'}
@@ -58,12 +66,13 @@ do {
 
         # POST function handler response back to Runtime API
         if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]POST function handler response back to Runtime API'}
-        Send-FunctionHandlerResponse $private:InvocationResponse
+
+        Send-FunctionHandlerResponse $private:httpClient $private:InvocationResponse
     }
     catch {
         # POST function invocation error back to Runtime API
         if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') {Write-Host '[RUNTIME-bootstrap]POST function invocation error back to Runtime API'}
-        Send-FunctionHandlerError $_
+        Send-FunctionHandlerError $private:httpClient $_
     }
 
     # Cleanup

--- a/powershell-runtime/source/modules/Private/Get-LambdaNextInvocation.ps1
+++ b/powershell-runtime/source/modules/Private/Get-LambdaNextInvocation.ps1
@@ -12,38 +12,47 @@ function private:Get-LambdaNextInvocation {
         .Notes
             If there is an error calling the Runtime API endpoint, this is ignored and retried as part of the event loop.
     #>
+    param (
+        [Parameter(Position=0)]
+        [System.Net.Http.HttpClient]$private:HttpClient
+    )
 
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Start: Get-LambdaNextInvocation' }
 
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Create GET request to Runtime API' }
-    $private:incomingWebRequest = [System.Net.WebRequest]::Create("http://$env:AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/next")
-    $private:incomingWebRequest.Headers.Add('User-Agent', "aws-lambda-powershell/$env:POWERSHELL_VERSION")
+
+    $private:request = [System.Net.Http.HttpRequestMessage]::new()
+    $private:request.Headers.Add('User-Agent', "aws-lambda-powershell/$env:POWERSHELL_VERSION")
+    $private:request.Method = 'GET'
+    $private:request.RequestUri = "http://$env:AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/next"
+
     try {
         # Get the next invocation
         if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Get the next invocation' }
-        $private:incomingWebResponse = $private:incomingWebRequest.GetResponse()
+        $private:response = $private:HttpClient.SendAsync($private:request).GetAwaiter().GetResult()
     }
     catch {
         # If there is an error calling the Runtime API endpoint, ignore which tries again
+        if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-Get-LambdaNextInvocation]Exception caught: $($_.Exception.Message)" }
         continue
     }
 
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Read response stream' }
-    $private:incomingStreamReader = [System.IO.StreamReader]::new($private:incomingWebResponse.GetResponseStream())
-    $private:incomingEvent = $private:incomingStreamReader.ReadToEnd()
-    $private:incomingStreamReader.Dispose()
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Read the response content' }
+    $private:incomingEvent = $private:response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
 
-    # If there is no response from the Runtime API endpoint, ignore which tries again.
-    if ([String]::IsNullOrWhiteSpace($private:incomingEvent)) { continue }
-    else {
-        $private:responseStream = $null
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Generate the correct response headers' }
+    $private:incomingHeaders = @{}
+    foreach ($private:header in $private:response.Headers) {
+        $private:incomingHeaders[$private:header.Key] = $private:header.Value
     }
 
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Create response object' }
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Create a response object' }
     $private:NextInvocationResponseObject = [pscustomobject]@{
-        headers       = $private:incomingWebResponse.Headers
+        headers       = $private:incomingHeaders
         incomingEvent = $private:incomingEvent
     }
+
+    if ($private:response) { $private:response.Dispose() }
     if ($private:responseStream) { $private:responseStream.Dispose() }
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Get-LambdaNextInvocation]Return response object' }
     return [pscustomobject]$private:NextInvocationResponseObject

--- a/powershell-runtime/source/modules/Private/Send-FunctionHandlerError.ps1
+++ b/powershell-runtime/source/modules/Private/Send-FunctionHandlerError.ps1
@@ -33,5 +33,5 @@ function private:Send-FunctionHandlerError {
         Key = 'Lambda-Runtime-Function-Error-Type'
         Value = '{0}.{1}' -f $private:Exception.CategoryInfo.Category, $private:Exception.CategoryInfo.Reason
     })
-    SendRuntimeApiRequest $private:HttpClient $private:uri $private:body $private:headers
+    _SendRuntimeApiRequest $private:HttpClient $private:uri $private:body $private:headers
 }

--- a/powershell-runtime/source/modules/Private/Send-FunctionHandlerResponse.ps1
+++ b/powershell-runtime/source/modules/Private/Send-FunctionHandlerResponse.ps1
@@ -14,24 +14,15 @@ function private:Send-FunctionHandlerResponse {
     #>
     [CmdletBinding()]
     param (
+        [Parameter(Position=0)]
+        [System.Net.Http.HttpClient]$private:HttpClient,
+
+        [Parameter(Position=1)]
         $private:InvocationResponse
     )
 
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Send-FunctionHandlerResponse]Start: Send-FunctionHandlerResponse' }
+    $private:uri = "http://$env:AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/$env:AWS_LAMBDA_RUNTIME_AWS_REQUEST_ID/response"
 
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Send-FunctionHandlerResponse]Create POST request to Runtime API' }
-    $private:responseUri = "http://$env:AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/$env:AWS_LAMBDA_RUNTIME_AWS_REQUEST_ID/response"
-    $private:responseRequest = [System.Net.WebRequest]::Create($private:responseUri)
-    $private:responseRequest.Headers.Add('User-Agent', "aws-lambda-powershell/$env:POWERSHELL_VERSION")
-    $private:responseRequest.Method = 'POST'
-
-    if (-not([String]::IsNullOrWhiteSpace($private:InvocationResponse))) {
-        if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Send-FunctionHandlerResponse]Sending POST request to Runtime API' }
-        $private:responseByteArray = [System.Text.Encoding]::UTF8.GetBytes($private:InvocationResponse)
-        $private:responseStream = $private:responseRequest.GetRequestStream()
-        $private:responseStream.Write($private:responseByteArray, 0, $private:responseByteArray.Length)
-    }
-
-    $null = $private:responseRequest.GetResponse()
-    if ($private:responseStream) { $private:responseStream.Dispose() }
+    SendRuntimeApiRequest $private:HttpClient $private:uri $private:InvocationResponse
 }

--- a/powershell-runtime/source/modules/Private/Send-FunctionHandlerResponse.ps1
+++ b/powershell-runtime/source/modules/Private/Send-FunctionHandlerResponse.ps1
@@ -24,5 +24,5 @@ function private:Send-FunctionHandlerResponse {
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Send-FunctionHandlerResponse]Start: Send-FunctionHandlerResponse' }
     $private:uri = "http://$env:AWS_LAMBDA_RUNTIME_API/2018-06-01/runtime/invocation/$env:AWS_LAMBDA_RUNTIME_AWS_REQUEST_ID/response"
 
-    SendRuntimeApiRequest $private:HttpClient $private:uri $private:InvocationResponse
+    _SendRuntimeApiRequest $private:HttpClient $private:uri $private:InvocationResponse
 }

--- a/powershell-runtime/source/modules/Private/Set-LambdaContext.ps1
+++ b/powershell-runtime/source/modules/Private/Set-LambdaContext.ps1
@@ -12,11 +12,6 @@ function Private:Set-LambdaContext {
 
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Set-LambdaContext]Start: Set-LambdaContext' }
 
-    # Importing .NET class from .cs file to support the script property "RemainingTime" and method "getRemainingTimeInMillis".
-    # This is taken from the Lambda .Net runtime LambdaContext code: https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.Core/ILambdaContext.cs
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Set-LambdaContext]Importing .NET class from .cs file to support script properties and method' }
-    Add-Type -TypeDefinition ([System.IO.File]::ReadAllText('/opt/PowerShellLambdaContext.cs'))
-
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-Set-LambdaContext]Creating LambdaContext' }
     $private:LambdaContext = [Amazon.Lambda.PowerShell.Internal.LambdaContext]::new(
         $env:AWS_LAMBDA_FUNCTION_NAME,
@@ -30,6 +25,6 @@ function Private:Set-LambdaContext {
         $env:AWS_LAMBDA_RUNTIME_CLIENT_CONTEXT,
         [double]$env:AWS_LAMBDA_RUNTIME_DEADLINE_MS
     )
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-Set-LambdaContext]Return LambdaContext: $($private:LambdaContext)" }
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-Set-LambdaContext]Return LambdaContext: $(ConvertTo-Json -InputObject $private:LambdaContext -Compress)" }
     return $private:LambdaContext
 }

--- a/powershell-runtime/source/modules/Private/_SendRuntimeApiPost.ps1
+++ b/powershell-runtime/source/modules/Private/_SendRuntimeApiPost.ps1
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+function SendRuntimeApiRequest {
+    [CmdletBinding()]
+    param (
+        [Parameter(Position=0)]
+        [System.Net.Http.HttpClient]$private:HttpClient,
+
+        [Parameter(Position=1)]
+        [string]$private:Uri,
+
+        [Parameter(Position=2)]
+        $private:Body,
+
+        [Parameter(Position=3)]
+        $private:Headers
+    )
+
+    $private:request = [System.Net.Http.HttpRequestMessage]::new()
+    $private:request.Headers.Add('User-Agent', "aws-lambda-powershell/$env:POWERSHELL_VERSION")
+    if ($private:Headers) {
+        $private:Headers | ForEach-Object {
+            $private:request.Headers.Add($_.Key, $_.Value)
+        }
+    }
+    $private:request.Method = 'POST'
+    $private:request.RequestUri = $private:Uri
+    $private:request.Content = [System.Net.Http.StringContent]::new($private:Body)
+
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-SendRuntimeApiRequest]Sending POST request to Runtime API' }
+    $private:runtimeResponse = $private:HttpClient.SendAsync($private:request).GetAwaiter().GetResult()
+    $private:runtimeResponseContent =  $private:runtimeResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-SendRuntimeApiRequest]Runtime API Response: $private:runtimeResponseContent" }
+
+    if ($private:runtimeResponse) { $private:runtimeResponse.Dispose() }
+}

--- a/powershell-runtime/source/modules/Private/_SendRuntimeApiPost.ps1
+++ b/powershell-runtime/source/modules/Private/_SendRuntimeApiPost.ps1
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-function SendRuntimeApiRequest {
+function _SendRuntimeApiRequest {
     [CmdletBinding()]
     param (
         [Parameter(Position=0)]
@@ -11,26 +11,28 @@ function SendRuntimeApiRequest {
         [string]$private:Uri,
 
         [Parameter(Position=2)]
-        $private:Body,
+        [string]$private:Body,
 
         [Parameter(Position=3)]
-        $private:Headers
+        [array]$private:Header
     )
 
     $private:request = [System.Net.Http.HttpRequestMessage]::new()
     $private:request.Headers.Add('User-Agent', "aws-lambda-powershell/$env:POWERSHELL_VERSION")
-    if ($private:Headers) {
-        $private:Headers | ForEach-Object {
-            $private:request.Headers.Add($_.Key, $_.Value)
+    if ($private:Header) {
+        foreach ($h in $private:Header) {
+            $private:request.Headers.Add($h.Key, $h.Value)
         }
     }
     $private:request.Method = 'POST'
     $private:request.RequestUri = $private:Uri
     $private:request.Content = [System.Net.Http.StringContent]::new($private:Body)
 
-    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host '[RUNTIME-SendRuntimeApiRequest]Sending POST request to Runtime API' }
+    if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-SendRuntimeApiRequest]Sending request to Runtime API: $(ConvertTO-Json -Compress -InputObject $private:request -Depth 5)" }
+
     $private:runtimeResponse = $private:HttpClient.SendAsync($private:request).GetAwaiter().GetResult()
     $private:runtimeResponseContent =  $private:runtimeResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+
     if ($env:POWERSHELL_RUNTIME_VERBOSE -eq 'TRUE') { Write-Host "[RUNTIME-SendRuntimeApiRequest]Runtime API Response: $private:runtimeResponseContent" }
 
     if ($private:runtimeResponse) { $private:runtimeResponse.Dispose() }

--- a/powershell-runtime/source/modules/pwsh-runtime.psd1
+++ b/powershell-runtime/source/modules/pwsh-runtime.psd1
@@ -7,7 +7,7 @@
 RootModule = 'pwsh-runtime.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.5'
+ModuleVersion = '0.6'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core'
@@ -65,14 +65,14 @@ PowerShellVersion = '6.0'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
-    'Set-PSModulePath'
-    'Set-LambdaContext'
     'Get-Handler'
-    'Set-HandlerEnvironmentVariables'
     'Get-LambdaNextInvocation'
     'Invoke-FunctionHandler'
     'Send-FunctionHandlerResponse'
     'Send-FunctionHandlerError'
+    'Set-HandlerEnvironmentVariables'
+    'Set-LambdaContext'
+    'Set-PSModulePath'
 )
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = ''


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-lambda-powershell-runtime/issues/34

*Description of changes:*
This change primarily migrates all calls to the Lambda Custom Runtime endpoint from `System.Net.WebRequest` to `System.Net.Http.HttpClient`. 

There are some additional minor updates included, such as moving the `PowerShellLambdaContext.cs` import to only once during startup rather than on every request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
